### PR TITLE
Atualização do método File.exists para File.exist

### DIFF
--- a/lib/ruby_danfe/options.rb
+++ b/lib/ruby_danfe/options.rb
@@ -13,7 +13,7 @@ module RubyDanfe
 
     private
       def file
-        File.exists?("config/ruby_danfe.yml") ? File.open("config/ruby_danfe.yml").read : ""
+        File.exist?("config/ruby_danfe.yml") ? File.open("config/ruby_danfe.yml").read : ""
       end
 
       def config_yaml_load


### PR DESCRIPTION
Seguindo a documentação oficial do Ruby, agora é necessário atualizar o método File.exists para File.exist, o exists foi descontinuado e é necessário para o bom funcionamento da aplicação.

https://ruby-doc.org/core-2.5.1/File.html#exists-3F-method